### PR TITLE
:wrench: ユニットテストはテスト用のデータベースで実行されるようになる

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # kyoruni/chie-box
 
+## セットアップ
+
+```bash
+# 環境設定ファイルをコピー
+$ cp backend/.env.example backend/.env
+$ cp backend/.env.testing.example backend/.env.testing
+
+# コンテナ起動
+$ docker compose up -d --build
+
+# APP_KEY 生成
+$ docker compose exec php php artisan key:generate
+$ docker compose exec php php artisan key:generate --env=testing
+
+# マイグレーション & シード
+$ docker compose exec php php artisan migrate --seed
+```
+
 ## 起動方法
 
 ```bash

--- a/backend/.env.testing.example
+++ b/backend/.env.testing.example
@@ -1,0 +1,12 @@
+APP_NAME=Laravel
+APP_ENV=testing
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost:8080
+
+DB_CONNECTION=pgsql
+DB_HOST=db
+DB_PORT=5432
+DB_DATABASE=chiebox_test
+DB_USERNAME=postgres
+DB_PASSWORD=secret

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,6 +3,7 @@
 .env
 .env.backup
 .env.production
+.env.testing
 .phpactor.json
 .phpunit.result.cache
 /.fleet

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -23,14 +23,9 @@
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
-        <env name="DB_URL" value=""/>
+        <env name="DB_DATABASE" value="chiebox_test"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
-        <env name="PULSE_ENABLED" value="false"/>
-        <env name="TELESCOPE_ENABLED" value="false"/>
-        <env name="NIGHTWATCH_ENABLED" value="false"/>
     </php>
 </phpunit>

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,12 +7,6 @@ services:
       - ./:/home/chie-box
     depends_on:
       - db
-    environment:
-      - DB_CONNECTION=pgsql
-      - DB_HOST=db
-      - DB_DATABASE=chiebox
-      - DB_USERNAME=postgres
-      - DB_PASSWORD=secret
   nginx:
     build:
       context: ./nginx

--- a/postgresql/init.sql
+++ b/postgresql/init.sql
@@ -1,1 +1,6 @@
 CREATE SCHEMA IF NOT EXISTS app;
+
+-- テスト用データベース
+CREATE DATABASE chiebox_test;
+\c chiebox_test
+CREATE SCHEMA IF NOT EXISTS app;


### PR DESCRIPTION
## 概要
- テスト用データベース（`chiebox_test`）を導入し、テスト実行時に開発データが消えないようにした

## 課題
- Closes #14

## 変更内容
### （1）`postgresql/init.sql`
- テスト用データベース `chiebox_test` の作成と `app` スキーマの作成を追加

### （2）`backend/.env.testing.example`
- テスト用環境設定のテンプレートを新規作成（`DB_DATABASE=chiebox_test`）

### （3）`backend/.gitignore`
- `.env.testing` を除外対象に追加

### （4）`backend/phpunit.xml`
- デフォルトの SQLite 設定（`DB_CONNECTION=sqlite`, `DB_DATABASE=:memory:`, `DB_URL`）を削除
- `DB_DATABASE=chiebox_test` を追加してテスト用DBを使用
- 不要な env 設定（PULSE, TELESCOPE, NIGHTWATCH）を削除

### （5）`compose.yaml`
- php サービスの `environment`（DB接続情報）を削除。`.env` と重複しており、`.env.testing` の設定を上書きする原因になっていた

### （6）`README.md`
- 初回セットアップ手順を追加（env ファイルのコピー、APP_KEY 生成、マイグレーション & シード）

## 変更種別
- [ ] 機能追加
- [ ] 不具合修正
- [ ] リファクタリング
- [ ] テスト追加
- [x] その他（内容：テスト環境の改善）