### PR TITLE
:wrench: 回答API作成

### DIFF
--- a/backend/app/Http/Controllers/AnswerController.php
+++ b/backend/app/Http/Controllers/AnswerController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreAnswerRequest;
+use App\Http\Requests\UpdateAnswerRequest;
+use App\Models\Answer;
+use App\Models\Question;
+use Illuminate\Http\JsonResponse;
+
+class AnswerController extends Controller
+{
+    public function store(StoreAnswerRequest $request, Question $question): JsonResponse
+    {
+        $answer = Answer::create([
+            ...$request->validated(),
+            'question_id' => $question->id,
+        ]);
+
+        return response()->json(['data' => $answer], 201);
+    }
+
+    public function update(UpdateAnswerRequest $request, Answer $answer): JsonResponse
+    {
+        $answer->update($request->validated());
+
+        return response()->json(['data' => $answer]);
+    }
+
+    public function destroy(Answer $answer): JsonResponse
+    {
+        $answer->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Http/Requests/StoreAnswerRequest.php
+++ b/backend/app/Http/Requests/StoreAnswerRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAnswerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'user_id' => ['required', 'exists:users,id'],
+            'body' => ['required', 'string'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/UpdateAnswerRequest.php
+++ b/backend/app/Http/Requests/UpdateAnswerRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateAnswerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'body' => ['sometimes', 'required', 'string'],
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,6 +1,11 @@
 <?php
 
+use App\Http\Controllers\AnswerController;
 use App\Http\Controllers\QuestionController;
 use Illuminate\Support\Facades\Route;
 
 Route::apiResource('questions', QuestionController::class);
+
+Route::post('questions/{question}/answers', [AnswerController::class, 'store']);
+Route::put('answers/{answer}', [AnswerController::class, 'update']);
+Route::delete('answers/{answer}', [AnswerController::class, 'destroy']);

--- a/backend/tests/Feature/AnswerApiTest.php
+++ b/backend/tests/Feature/AnswerApiTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use App\Models\Answer;
+use App\Models\Question;
+use App\Models\User;
+
+describe('回答投稿 API', function () {
+    it('回答を投稿できる', function () {
+        // GIVEN
+        $question = Question::factory()->create();
+        $user = User::factory()->create();
+
+        // WHEN
+        $response = $this->postJson("/api/questions/{$question->id}/answers", [
+            'user_id' => $user->id,
+            'body' => 'テスト回答本文',
+        ]);
+
+        // THEN
+        $response->assertCreated()
+            ->assertJsonPath('data.body', 'テスト回答本文');
+
+        $this->assertDatabaseHas('answers', [
+            'question_id' => $question->id,
+            'user_id' => $user->id,
+            'body' => 'テスト回答本文',
+        ]);
+    });
+
+    it('本文なしではバリデーションエラーになる', function () {
+        // GIVEN
+        $question = Question::factory()->create();
+        $user = User::factory()->create();
+
+        // WHEN
+        $response = $this->postJson("/api/questions/{$question->id}/answers", [
+            'user_id' => $user->id,
+        ]);
+
+        // THEN
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors('body');
+    });
+
+    it('ユーザーIDなしではバリデーションエラーになる', function () {
+        // GIVEN
+        $question = Question::factory()->create();
+
+        // WHEN
+        $response = $this->postJson("/api/questions/{$question->id}/answers", [
+            'body' => 'テスト回答本文',
+        ]);
+
+        // THEN
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors('user_id');
+    });
+
+    it('存在しない質問には回答できない', function () {
+        // GIVEN
+        $user = User::factory()->create();
+
+        // WHEN
+        $response = $this->postJson('/api/questions/999/answers', [
+            'user_id' => $user->id,
+            'body' => 'テスト回答本文',
+        ]);
+
+        // THEN
+        $response->assertNotFound();
+    });
+});
+
+describe('回答更新 API', function () {
+    it('回答を更新できる', function () {
+        // GIVEN
+        $answer = Answer::factory()->create(['body' => '更新前の本文']);
+
+        // WHEN
+        $response = $this->putJson("/api/answers/{$answer->id}", [
+            'body' => '更新後の本文',
+        ]);
+
+        // THEN
+        $response->assertOk()
+            ->assertJsonPath('data.body', '更新後の本文');
+
+        $this->assertDatabaseHas('answers', [
+            'id' => $answer->id,
+            'body' => '更新後の本文',
+        ]);
+    });
+
+    it('存在しない回答の更新は404を返す', function () {
+        // GIVEN（回答が存在しない状態）
+
+        // WHEN
+        $response = $this->putJson('/api/answers/999', [
+            'body' => '更新後の本文',
+        ]);
+
+        // THEN
+        $response->assertNotFound();
+    });
+});
+
+describe('回答削除 API', function () {
+    it('回答を削除できる', function () {
+        // GIVEN
+        $answer = Answer::factory()->create();
+
+        // WHEN
+        $response = $this->deleteJson("/api/answers/{$answer->id}");
+
+        // THEN
+        $response->assertNoContent();
+
+        $this->assertDatabaseMissing('answers', [
+            'id' => $answer->id,
+        ]);
+    });
+
+    it('存在しない回答の削除は404を返す', function () {
+        // GIVEN（回答が存在しない状態）
+
+        // WHEN
+        $response = $this->deleteJson('/api/answers/999');
+
+        // THEN
+        $response->assertNotFound();
+    });
+});


### PR DESCRIPTION
## 概要
- 回答APIのCRUD操作（投稿・更新・削除）を実装

## 課題
- Closes #10

## 変更内容
### （1）`backend/app/Http/Controllers/AnswerController.php`（新規）
- `store`: 質問に対する回答を投稿（`POST /api/questions/{question}/answers`）
- `update`: 回答を更新（`PUT /api/answers/{answer}`）
- `destroy`: 回答を削除（`DELETE /api/answers/{answer}`）

### （2）`backend/app/Http/Requests/StoreAnswerRequest.php`（新規）
- `user_id`（必須、usersテーブルに存在）と `body`（必須、文字列）のバリデーション

### （3）`backend/app/Http/Requests/UpdateAnswerRequest.php`（新規）
- `body`（sometimes、必須、文字列）のバリデーション

### （4）`backend/routes/api.php`
- 回答API用のルート3本を追加

### （5）`backend/tests/Feature/AnswerApiTest.php`（新規）
- 回答投稿API: 正常系1件 + 異常系3件（バリデーションエラー、存在しない質問）
- 回答更新API: 正常系1件 + 異常系1件（存在しない回答）
- 回答削除API: 正常系1件 + 異常系1件（存在しない回答）

## 変更種別
- [x] 機能追加
- [ ] 不具合修正
- [ ] リファクタリング
- [x] テスト追加
- [ ] その他（内容：）